### PR TITLE
corrected event group for BT_DISCOVERY_COMPLETED

### DIFF
--- a/libraries/BluetoothSerial/src/BluetoothSerial.cpp
+++ b/libraries/BluetoothSerial/src/BluetoothSerial.cpp
@@ -768,7 +768,7 @@ static bool waitForConnect(int timeout) {
 
 static bool waitForDiscovered(int timeout) {
     TickType_t xTicksToWait = timeout / portTICK_PERIOD_MS;
-    return (xEventGroupWaitBits(_spp_event_group, BT_DISCOVERY_COMPLETED, pdFALSE, pdTRUE, xTicksToWait) & BT_DISCOVERY_COMPLETED) != 0;
+    return (xEventGroupWaitBits(_bt_event_group, BT_DISCOVERY_COMPLETED, pdFALSE, pdTRUE, xTicksToWait) & BT_DISCOVERY_COMPLETED) != 0;
 }
 
 static bool waitForSDPRecord(int timeout) {


### PR DESCRIPTION
## Description of Change
Corrected event group of BT_DISCOVERY_COMPLETED from the _spp_event_group to the _bt_event_group.
This is it according to its usage procedure (for e.g. please check line 505).

## Tests scenarios
I have tested my Pull Request on Arduino-esp32 core v2.0.4 with ESP32

## Related links
none

